### PR TITLE
Re-enable commands.bd generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+commands.bd
 license.txt
 manifest.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,7 @@ metadata:
     - docker
   stage: build
   script:
+    - make commands.bd
     - make license.txt
     - make manifest.json
   after_script:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 license.txt:
 	cargo run --release --manifest-path nitrokey-3-firmware/utils/collect-license-info/Cargo.toml -- nitrokey-3-firmware/runners/nkpk/Cargo.toml "Nitrokey Passkey" > license.txt
 
+commands.bd:
+	cargo run --release --manifest-path nitrokey-3-firmware/utils/gen-commands-bd/Cargo.toml -- nitrokey-3-firmware/runners/nkpk/Cargo.toml > $@
+
 manifest.json:
 	sed "s/@VERSION@/`git describe --always`/g" utils/manifest.template.json > manifest.json


### PR DESCRIPTION
While this is not needed for the firmware container itself, it is used by the tooling to extract the encoded firmware version.